### PR TITLE
Fix build problem on mono/Mac

### DIFF
--- a/Raspberry.IO.Interop/ControlDevice.cs
+++ b/Raspberry.IO.Interop/ControlDevice.cs
@@ -8,31 +8,29 @@ namespace Raspberry.IO.Interop
     /// </summary>
     public class ControlDevice : IControlDevice
     {
-        #region Classes 
-
-        private static class GenericIoControl<T> {
-        
-            #region Libc imports
-
-            [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
-            public static extern int ioctl(int descriptor, UInt32 request, ref T data);
-            
-            [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
-            public static extern int ioctl(int descriptor, UInt32 request, T data);
-            
-            #endregion
-        }
-        #endregion
-
+       
         #region Fields
-        private readonly IFile file;
-        private readonly bool disposeFile;
+        /// <summary>
+        /// Device file used for communication
+        /// </summary>
+        protected readonly IFile file;
+        
+        /// <summary>
+        /// If <c>true</c>, <see cref="file"/> will be disposed on <see cref="ControlDevice.Dispose"/>
+        /// </summary>
+        protected readonly bool disposeFile;
 
         #endregion
 
         #region Libc imports
         [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
         private static extern int ioctl(int descriptor, UInt32 request, IntPtr data);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int ioctl(int descriptor, UInt32 request, ref UInt32 data);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int ioctl(int descriptor, UInt32 request, ref byte data);
         #endregion
 
         #region Instance Management
@@ -78,27 +76,26 @@ namespace Raspberry.IO.Interop
         #endregion
 
         #region Methods
+
         /// <summary>
         /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
         /// </summary>
-        /// <typeparam name="T">Data type that will be marshaled and send.</typeparam>
         /// <param name="request">A device-dependent request code.</param>
         /// <param name="data">The data to be transmitted.</param>
         /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
-        public int Control<T>(UInt32 request, ref T data) {
-            var result = GenericIoControl<T>.ioctl(file.Descriptor, request, ref data);
+        public int Control(UInt32 request, ref UInt32 data) {
+            var result = ioctl(file.Descriptor, request, ref data);
             return result;
         }
 
         /// <summary>
         /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
         /// </summary>
-        /// <typeparam name="T">Data type that will be marshaled and send.</typeparam>
         /// <param name="request">A device-dependent request code.</param>
         /// <param name="data">The data to be transmitted.</param>
         /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
-        public int Control<T>(uint request, T data) {
-            var result = GenericIoControl<T>.ioctl(file.Descriptor, request, data);
+        public int Control(UInt32 request, ref byte data) {
+            var result = ioctl(file.Descriptor, request, ref data);
             return result;
         }
 

--- a/Raspberry.IO.SerialPeripheralInterface/ISpiControlDevice.cs
+++ b/Raspberry.IO.SerialPeripheralInterface/ISpiControlDevice.cs
@@ -1,34 +1,27 @@
 ﻿using System;
+using Raspberry.IO.Interop;
 
-namespace Raspberry.IO.Interop
+namespace Raspberry.IO.SerialPeripheralInterface
 {
     /// <summary>
-    /// A Linux I/O control device.
+    /// A Linux I/O control device that additionally can send/receive SPI data structures.
     /// </summary>
-    public interface IControlDevice : IDisposable
+    public interface ISpiControlDevice : IControlDevice
     {
         /// <summary>
         /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
         /// </summary>
         /// <param name="request">A device-dependent request code.</param>
-        /// <param name="data">The data to be transmitted.</param>
+        /// <param name="data">The SPI control data to be transmitted.</param>
         /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
-        int Control(UInt32 request, ref UInt32 data);
+        int Control(UInt32 request, ref SpiTransferControlStructure data);
 
         /// <summary>
         /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
         /// </summary>
         /// <param name="request">A device-dependent request code.</param>
-        /// <param name="data">The data to be transmitted.</param>
+        /// <param name="data">The SPI control data structures to be transmitted.</param>
         /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
-        int Control(UInt32 request, ref byte data);
-
-        /// <summary>
-        /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
-        /// </summary>
-        /// <param name="request">A device-dependent request code.</param>
-        /// <param name="data">An untyped pointer to memory that contains the command/request data.</param>
-        /// <returns></returns>
-        int Control(UInt32 request, IntPtr data);
+        int Control(UInt32 request, SpiTransferControlStructure[] data);
     }
 }

--- a/Raspberry.IO.SerialPeripheralInterface/NativeSpiConnection.cs
+++ b/Raspberry.IO.SerialPeripheralInterface/NativeSpiConnection.cs
@@ -25,7 +25,7 @@ namespace Raspberry.IO.SerialPeripheralInterface
         #endregion
 
         #region Fields
-        private readonly IControlDevice deviceFile;
+        private readonly ISpiControlDevice deviceFile;
         private UInt16 delay;
         private UInt32 maxSpeed;
         private UInt32 mode;
@@ -38,7 +38,7 @@ namespace Raspberry.IO.SerialPeripheralInterface
         /// Creates a new instance of the <see cref="NativeSpiConnection"/> class.
         /// </summary>
         /// <param name="deviceFile">A control device (IOCTL) to the device file (e.g. /dev/spidev0.0).</param>
-        public NativeSpiConnection(IControlDevice deviceFile) {
+        public NativeSpiConnection(ISpiControlDevice deviceFile) {
             this.deviceFile = deviceFile;
         }
 
@@ -47,7 +47,7 @@ namespace Raspberry.IO.SerialPeripheralInterface
         /// </summary>
         /// <param name="deviceFile">A control device (IOCTL) to the device file (e.g. /dev/spidev0.0).</param>
         /// <param name="settings">Connection settings</param>
-        public NativeSpiConnection(IControlDevice deviceFile, SpiConnectionSettings settings)
+        public NativeSpiConnection(ISpiControlDevice deviceFile, SpiConnectionSettings settings)
             : this(deviceFile)
         {
             Init(settings);
@@ -59,7 +59,7 @@ namespace Raspberry.IO.SerialPeripheralInterface
         /// <param name="deviceFilePath">Full path to the SPI device file (e.g. /dev/spidev0.0).</param>
         /// <param name="settings">Connection settings</param>
         public NativeSpiConnection(string deviceFilePath, SpiConnectionSettings settings) 
-            : this(new ControlDevice(new UnixFile(deviceFilePath, UnixFileMode.ReadWrite)), settings)
+            : this(new SpiControlDevice(new UnixFile(deviceFilePath, UnixFileMode.ReadWrite)), settings)
         {}
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Raspberry.IO.SerialPeripheralInterface
         /// </summary>
         /// <param name="deviceFilePath">Full path to the SPI device file (e.g. /dev/spidev0.0).</param>
         public NativeSpiConnection(string deviceFilePath)
-            : this(new ControlDevice(new UnixFile(deviceFilePath, UnixFileMode.ReadWrite))) 
+            : this(new SpiControlDevice(new UnixFile(deviceFilePath, UnixFileMode.ReadWrite))) 
         {}
 
         /// <summary>

--- a/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
+++ b/Raspberry.IO.SerialPeripheralInterface/Raspberry.IO.SerialPeripheralInterface.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Interop\Interop.cs" />
     <Compile Include="Endianness.cs" />
     <Compile Include="Interop\SpiTransferControlStructure.cs" />
+    <Compile Include="ISpiControlDevice.cs" />
     <Compile Include="ISpiTransferBuffer.cs" />
     <Compile Include="ISpiTransferBufferCollection.cs" />
     <Compile Include="NativeSpiConnection.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="SpiConnection.cs" />
     <Compile Include="EnumTypes\SpiMode.cs" />
     <Compile Include="SpiConnectionSettings.cs" />
+    <Compile Include="SpiControlDevice.cs" />
     <Compile Include="SpiSlaveSelectionContext.cs" />
     <Compile Include="SpiTransferBuffer.cs" />
     <Compile Include="Exceptions\WriteOnlyTransferBufferException.cs" />

--- a/Raspberry.IO.SerialPeripheralInterface/SpiControlDevice.cs
+++ b/Raspberry.IO.SerialPeripheralInterface/SpiControlDevice.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Raspberry.IO.Interop;
+
+namespace Raspberry.IO.SerialPeripheralInterface
+{
+    /// <summary>
+    /// A Linux I/O control device that additionally can send/receive SPI data structures.
+    /// </summary>
+    public class SpiControlDevice : ControlDevice, ISpiControlDevice
+    {
+        #region Libc imports
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int ioctl(int descriptor, UInt32 request, ref SpiTransferControlStructure data);
+
+        [DllImport("libc", EntryPoint = "ioctl", SetLastError = true)]
+        private static extern int ioctl(int descriptor, UInt32 request, SpiTransferControlStructure[] data);
+        #endregion
+
+        #region Instance Management
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpiControlDevice"/> class.
+        /// </summary>
+        /// <param name="file">A opened special file that can be controlled using ioctl-system calls.</param>
+        /// <remarks><paramref name="file"/> will be disposed if the user calls Dispose on this instance.</remarks>
+        public SpiControlDevice(IFile file) 
+            :base(file)
+        {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpiControlDevice"/> class.
+        /// </summary>
+        /// <param name="file">A opened special file that can be controlled using ioctl-system calls.</param>
+        /// <param name="disposeFile">If <c>true</c> the supplied <paramref name="file"/> will be disposed if the user calls Dispose on this instance.</param>
+        public SpiControlDevice(IFile file, bool disposeFile) 
+            :base(file, disposeFile){}
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
+        /// </summary>
+        /// <param name="request">A device-dependent request code.</param>
+        /// <param name="data">The data to be transmitted.</param>
+        /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
+        public int Control(UInt32 request, ref SpiTransferControlStructure data) {
+            var result = ioctl(file.Descriptor, request, ref data);
+            return result;
+        }
+        
+        /// <summary>
+        /// The function manipulates the underlying device parameters of special files. In particular, many operating characteristics of character special files (e.g. terminals) may be controlled with ioctl requests.
+        /// </summary>
+        /// <param name="request">A device-dependent request code.</param>
+        /// <param name="data">The SPI control data structures to be transmitted.</param>
+        /// <returns>Usually, on success zero is returned. A few ioctls use the return value as an output parameter and return a nonnegative value on success. On error, -1 is returned, and errno is set appropriately.</returns>
+        public int Control(UInt32 request, SpiTransferControlStructure[] data) {
+            var result = ioctl(file.Descriptor, request, data);
+            return result;
+        }
+        #endregion
+    }
+}

--- a/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/NativeSpiConnectionSpecs.cs
+++ b/UnitTests/Tests.Raspberry.IO.SerialPeripheralInterface/NativeSpiConnectionSpecs.cs
@@ -5,7 +5,6 @@ using FakeItEasy;
 using FakeItEasy.ExtensionSyntax.Full;
 using FluentAssertions;
 using NUnit.Framework;
-using Raspberry.IO.Interop;
 using Raspberry.IO.SerialPeripheralInterface;
 
 // ReSharper disable once CheckNamespace
@@ -21,7 +20,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
         
         private SpiConnectionSettings settings;
         private NativeSpiConnection connection;
-        private IControlDevice controlDevice;
+        private ISpiControlDevice controlDevice;
 
         protected override void EstablishContext() {
             settings = new SpiConnectionSettings {
@@ -31,7 +30,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
                 MaxSpeed = SPEED_IN_HZ
             };
 
-            controlDevice = A.Fake<IControlDevice>();
+            controlDevice = A.Fake<ISpiControlDevice>();
         }
 
         protected override void BecauseOf() {
@@ -107,7 +106,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
         private const int REQUESTED_SIZE = 100;
 
         private SpiConnectionSettings settings;
-        private IControlDevice controlDevice;
+        private ISpiControlDevice controlDevice;
         private NativeSpiConnection connection;
         private ISpiTransferBuffer buffer;
 
@@ -119,7 +118,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
                 MaxSpeed = SPEED_IN_HZ
             };
 
-            controlDevice = A.Fake<IControlDevice>();
+            controlDevice = A.Fake<ISpiControlDevice>();
             connection = new NativeSpiConnection(controlDevice, settings);
         }
 
@@ -158,7 +157,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
         private const int IOCTL_PINVOKE_RESULT_CODE = 1;
         private const int SPI_IOC_MESSAGE_1 = 0x40206b00;
 
-        private IControlDevice controlDevice;
+        private ISpiControlDevice controlDevice;
         private NativeSpiConnection connection;
         private ISpiTransferBuffer buffer;
         private int result;
@@ -174,7 +173,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
                 Speed = SPEED_IN_HZ
             };
             
-            controlDevice = A.Fake<IControlDevice>();
+            controlDevice = A.Fake<ISpiControlDevice>();
             controlDevice
                 .CallsTo(device => device.Control(A<uint>.Ignored, ref controlStructure))
                 .WithAnyArguments()
@@ -214,7 +213,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
         private const int IOCTL_PINVOKE_RESULT_CODE = 1;
         private const int SPI_IOC_MESSAGE_1 = 0x40206b00;
 
-        private IControlDevice controlDevice;
+        private ISpiControlDevice controlDevice;
         private NativeSpiConnection connection;
         private ISpiTransferBufferCollection collection;
         private ISpiTransferBuffer buffer;
@@ -222,7 +221,7 @@ namespace Tests.Raspberry.IO.SerialPeripheralInterface.NativeSpiConnectionSpecs
         private SpiTransferControlStructure controlStructure;
 
         protected override void EstablishContext() {
-            controlDevice = A.Fake<IControlDevice>();
+            controlDevice = A.Fake<ISpiControlDevice>();
             controlDevice
                 .CallsTo(device => device.Control(A<uint>.Ignored, A<SpiTransferControlStructure[]>.Ignored))
                 .Returns(IOCTL_PINVOKE_RESULT_CODE);


### PR DESCRIPTION
- ControlDevice: removed generic inner class
- ControlDevice: added ioctl-methods for UInt32 and byte data types
- new class+interface ISpiControlDevice that features the required
  ioctl-methods using the SpiTransferControlStructure data type
- TODO: test on Raspberry Pi
